### PR TITLE
Update wrong URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Tested scalate templates :
 * Clone this repository  
 
 ```
-git clone git@github.com:adetante/play2-scalate.git
+git clone git://github.com/thusqed/play2.x-scalate.git
 ```
 * Build and publish the plugin to your local repository 
 


### PR DESCRIPTION
I couldn't clone the repo from the readme instructions, so changed it to the git readonly url.
